### PR TITLE
Bugfix, did not compile

### DIFF
--- a/src/crypto/mbedtls.c
+++ b/src/crypto/mbedtls.c
@@ -209,7 +209,7 @@ int32_t bctoolbox_x509_certificate_parse_path(bctoolbox_x509_certificate_t *cert
 }
 
 int32_t bctoolbox_x509_certificate_parse(bctoolbox_x509_certificate_t *cert, const char *buffer, size_t buffer_length) {
-	return ret = mbedtls_x509_crt_parse((mbedtls_x509_crt *)cert, (const unsigned char *)buffer, buffer_length);
+	return mbedtls_x509_crt_parse((mbedtls_x509_crt *)cert, (const unsigned char *)buffer, buffer_length);
 }
 
 int32_t bctoolbox_x509_certificate_get_der_length(bctoolbox_x509_certificate_t *cert) {


### PR DESCRIPTION
Trying to compile caused the following error:

pi@raspberrypi:~/bctoolbox $ make
[ 25%] Building C object src/CMakeFiles/bctoolbox.dir/crypto/mbedtls.c.o
/home/pi/bctoolbox/src/crypto/mbedtls.c: In function ‘bctoolbox_x509_certificate_parse’:
/home/pi/bctoolbox/src/crypto/mbedtls.c:212:9: error: ‘ret’ undeclared (first use in this function)
  return ret = mbedtls_x509_crt_parse((mbedtls_x509_crt *)cert, (const unsigned char *)buffer, buffer_length);

removed "ret =" in line 212 to fix